### PR TITLE
allow files arg to be array of globs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,10 @@ const returnStorybookConfig = ({
   filename: "remoteEntry.js",
   shared: returnShared(shared),
   ...prepareExposesObject(
-    returnPaths(files.paths, files.storiesExtension),
+    returnPaths(
+      Array.isArray(files) ? files : files.paths,
+      files.storiesExtension
+    ),
     files.removePrefix
   ),
   ...prepareRemotesObject(remotes),

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -345,7 +345,7 @@ test("it returns the simple config for storybook if only names and files are pas
   );
 });
 
-test.skip("it returns the simple config for storybook if only names and files are passed", () => {
+test("it returns the simple config for storybook if only names and files are passed", () => {
   new StorybookWebpackFederationPlugin({
     name: "xolvio_ui",
     files: globs,


### PR DESCRIPTION
This PR adds the ability to simply pass an array of globs as `files` when instantiating the `StorybookWebpackFederationPlugin`.