### PR TITLE
replace all occurrences of - in name with _

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,14 +42,16 @@ const returnRemotes = (remotes) =>
 const prepareRemotesObject = (remotes) =>
   remotes.length > 0 ? { remotes: returnRemotes(remotes) } : {};
 
+const prepareName = (name) => name.replace(/-/g, "_");
+
 const returnStorybookConfig = ({
   name = "app",
   files = {},
   remotes = [],
   shared,
 }) => ({
-  name,
-  library: { type: "var", name },
+  name: prepareName(name),
+  library: { type: "var", name: prepareName(name) },
   filename: "remoteEntry.js",
   shared: returnShared(shared),
   ...prepareExposesObject(
@@ -70,6 +72,7 @@ class StorybookWebpackFederationPlugin {
 module.exports = {
   returnPaths,
   prepareExposesObject,
+  prepareName,
   returnShared,
   returnStorybookConfig,
   returnAppConfig,

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -115,6 +115,12 @@ test("prepareExposesObject works with different path prefix", () => {
   });
 });
 
+const { prepareName } = require("./index")
+
+test('replaces all - with  _ in the name', () => {
+  expect(prepareName('foo-bar_fizz-buzz')).toEqual('foo_bar_fizz_buzz')
+})
+
 const { returnShared } = require("./index");
 
 test("return shared returns react and react-dom by default", () => {


### PR DESCRIPTION
The `ModuleFederationPlugin` causes an error to be thrown **at runtime** when using a name with a `-` in it. This is because the new Webpack output, the `remoteEntry.js` in this case, attempts to create a JS variable with the given name, ergo the first '-' in the name produces a SyntaxError.

This PR replaces all instances of '-'  in the `name` with `_`. I admit this is a bit esoteric though. Maybe this should be fixed in the `ModuleFederationPlugin` somehow? Open to thoughts.