### PR TITLE
dedupe shared

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ const prepareExposesObject = (paths, removePrefix = "./src/") => {
 };
 
 const returnShared = (extraToShare = []) => {
-  return ["react", "react-dom", ...extraToShare];
+  return [...new Set(["react", "react-dom", ...extraToShare])];
 };
 
 const returnRemotes = (remotes) =>

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -130,6 +130,15 @@ test("return shared compiles the defaults with the passed items", () => {
   ]);
 });
 
+test("return shared compiles the defaults with the passed items and dedupes", () => {
+  expect(returnShared(["react", "react-dom", "styled-components", "modifyjs"])).toEqual([
+    "react",
+    "react-dom",
+    "styled-components",
+    "modifyjs",
+  ]);
+});
+
 const { returnStorybookConfig } = require("./index");
 
 test("returnStorybookConfig works", () => {


### PR DESCRIPTION
In the event that I have additional deps in `shared`, I think having to omit `react` and `react-dom`, when using this plugin would be a gotcha. This PR dedupes `shared`, so it's not an issue. :) 