### PR TITLE
remove /index from expose object key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,8 @@ const prepareExposesObject = (paths, removePrefix = "./src/") => {
               ...previousValue.exposes,
               [currentValue
                 .replace(removePrefix, "")
-                .replace(extension, "")]: currentValue,
+                .replace(extension, "")
+                .replace(/\/index$/, "")]: currentValue,
             },
           };
         },

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -55,6 +55,7 @@ console.log(
     "./src/components/icons/ShapesIcon.tsx",
     "./src/components/Sections.tsx",
     "./src/components/Title.tsx",
+    "./src/components/Button/index.tsx",
     "./src/elements/Background.tsx",
     "./src/elements/ButtonPrimary.tsx",
     "./src/elements/Confetti7Rows.tsx",
@@ -111,6 +112,16 @@ test("prepareExposesObject works with different path prefix", () => {
   ).toEqual({
     exposes: {
       "elements/Confetti7Rows": "./lib/elements/Confetti7Rows.ts",
+    },
+  });
+});
+
+test("prepareExposesObject removes index from the path", () => {
+  expect(
+    prepareExposesObject(["./src/components/Button/index.tsx"])
+  ).toEqual({
+    exposes: {
+      "components/Button": "./src/components/Button/index.tsx",
     },
   });
 });


### PR DESCRIPTION
I'll often organize components like such:

```
/Button
--| index.jsx
--|...
```
Where `index.jsx` is the barrel that I export any public  facing APIs of the module. Currently this is producing an `expose` object like:

```
{
   'Button/index': 'Button/index.jsx`
}
```

which means the import would have to be `import Button from 'xolvio_ui/Button/index'` which isn't very intuitive since I can usually omit the `index` part using regular `import/export` semantics.

This PR removes the `/index` at the end of the path so the `expose` object looks more like:
```
{
   'Button': 'Button/index.jsx`
}
```

which means the import would be just `import Button from 'xolvio_ui/Button'`