### PR TITLE
allow storiesExtension to be RegExp

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ Below you can find a description of the fields in the configuration for this plu
     // an array of globs to match your component files
     paths: ["./src/components/**/*.ts{,x}"],
 
-    // files with .stories. will get ignored, so they don't get exposed on the endpoints
-    storiesExtension: ".stories.",
+    // files with .stories. will get ignored, so they don't get exposed on the endpoints. Can also be a RegExp
+    storiesExtension: ".stories." | /\.stories\.,
 
      // so your App can import "xolvio_ui/components/Title" instead of  "xolvio_ui/src/components/Title"
     removePrefix: "./src/",

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,12 @@ const glob = require("glob");
 const path = require("path");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
 
-const returnPaths = (globs = [], storiesExtension = ".stories.") => {
+const returnPaths = (globs = [], storiesExtension = /\.stories\./) => {
   return globs
     .reduce((previousValue, currentValue) => {
       return [...previousValue, ...glob.sync(currentValue)];
     }, [])
-    .filter((p) => p.indexOf(storiesExtension) === -1);
+    .filter((p) => !new RegExp(storiesExtension).test(p));
 };
 
 const prepareExposesObject = (paths, removePrefix = "./src/") => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const glob = require("glob");
 const path = require("path");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
 
-const returnPaths = (globs = [], storiesExtension = /\.stories\./) => {
+const returnPaths = (globs = [], storiesExtension = /\.?stories\./) => {
   return globs
     .reduce((previousValue, currentValue) => {
       return [...previousValue, ...glob.sync(currentValue)];

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -46,6 +46,21 @@ test("returnPaths returns the compiled paths without stories", () => {
   ]);
 });
 
+test("returnPaths returns the compiled paths without stories using RegExp", () => {
+  expect(returnPaths(globs, /stories\./)).toEqual([
+    "./src/components/icons/FlipchartIcon.tsx",
+    "./src/components/icons/ScreenIcon.tsx",
+    "./src/components/icons/ShapesIcon.tsx",
+    "./src/components/Sections.tsx",
+    "./src/components/Title.tsx",
+    "./src/elements/Background.tsx",
+    "./src/elements/ButtonPrimary.tsx",
+    "./src/elements/Confetti7Rows.tsx",
+    "./src/elements/InlineButton.ts",
+    "./src/elements/typography.tsx",
+  ]);
+});
+
 const { prepareExposesObject } = require("./index");
 
 console.log(


### PR DESCRIPTION
This PR makes it such that `storiesExtension` can be a `string` or a `RegExp`. I ran into this use case while integrating with a project.

This  PR also makes it such that the default value for `storiesExtension` will match 0 or 1 leading `.`. This way  `foo.stories.jsx` and `stories.jsx` are matched. The use case for this is:

```
/Button
--| index.jsx
--| stories.jsx
```